### PR TITLE
Moved to new version of PyFd

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyfd" %}
-{% set version = "4.5.3" %}
+{% set version = "4.5.4" %}
 
 package:
    name: "{{ name }}"
@@ -7,7 +7,7 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: 5c5322dfe13229a5885ff17fd2bc99cba774c407db4ac6401a8481bb19c36179
+   sha256: 69361e042e02f21f4c2aef548458c699da82b438570f104950f220b008a05223
 
 build:
   run_exports:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Added in elif to string class in ctypes binding to allow strings.

This pull request updates the PyFd package with the following update:

Added in elif to string class in ctypes binding to allow strings

In Python2 the String class could be initialised using string type, since python2 does not differentiate between string and bytestring. But this is no longer true in python3, so the String function needs to be updated to enable strings to be parsed

