### PR TITLE
Py fd 4.5.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: 5febd0af60beb824d0bfdd295a708338dcd2052b041980140a5123acb73e534c
+   sha256: 8a3dc13a5726cf8fd700311632f4ceb754b99dcf4f90bbd8b77d87119af826a8
 
 build:
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyfd" %}
-{% set version = "4.5.4" %}
+{% set version = "4.5.6" %}
 
 package:
    name: "{{ name }}"
@@ -7,13 +7,13 @@ package:
 
 source:
    url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-   sha256: 69361e042e02f21f4c2aef548458c699da82b438570f104950f220b008a05223
+   sha256: 5febd0af60beb824d0bfdd295a708338dcd2052b041980140a5123acb73e534c
 
 build:
   run_exports:
     - {{ pin_subpackage("pyfd", max_pin="x") }}
   number: 0
-  skip: true  # [win or osx]
+  skip: true  # [not linux]
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This moves PyFd to version 4.5.6 that includes the `FdIOGetFrameFromBuf` used by the llvkafka (and hopefully soon the llkafkak-pyclient).